### PR TITLE
Fix updating of custom keyboard shortcuts

### DIFF
--- a/components/dialogs/help-dialog.tsx
+++ b/components/dialogs/help-dialog.tsx
@@ -113,25 +113,25 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
 
     e.preventDefault();
 
-    // Build key combination
-    const keys = [];
+    // Ignore modifier-only key presses so users can hold them
+    const pressedKey = e.key.toLowerCase();
+    if (["control", "alt", "shift", "meta"].includes(pressedKey)) {
+      return;
+    }
+
+    // Build key combination from currently held modifier keys
+    const keys = [] as string[];
     if (e.ctrlKey) keys.push("ctrl");
     if (e.altKey) keys.push("alt");
     if (e.shiftKey) keys.push("shift");
     if (e.metaKey) keys.push("meta");
 
-    // Add the main key if it's not a modifier
-    const key = e.key.toLowerCase();
-    if (!["control", "alt", "shift", "meta"].includes(key)) {
-      keys.push(key);
-    }
+    // Add the main key
+    keys.push(pressedKey);
 
-    // Only update if we have at least one key
-    if (keys.length > 0) {
-      updateShortcut(editingShortcut, keys.join("+"));
-      setListeningForKeys(false);
-      setEditingShortcut(null);
-    }
+    updateShortcut(editingShortcut, keys.join("+"));
+    setListeningForKeys(false);
+    setEditingShortcut(null);
   };
 
   // Copy shortcut to clipboard

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -240,6 +240,7 @@ export function saveShortcuts(shortcuts: KeyboardShortcut[]): void {
     // Only save id and keys to keep it minimal
     const toSave = shortcuts.map(({ id, keys }) => ({ id, keys }))
     localStorage.setItem("keyboard-shortcuts", JSON.stringify(toSave))
+    window.dispatchEvent(new Event("keyboardShortcutsChanged"))
   } catch (error) {
     console.error("Error saving keyboard shortcuts:", error)
   }
@@ -251,6 +252,9 @@ export function useKeyboardShortcuts() {
 
   useEffect(() => {
     setShortcuts(loadShortcuts())
+    const handler = () => setShortcuts(loadShortcuts())
+    window.addEventListener("keyboardShortcutsChanged", handler)
+    return () => window.removeEventListener("keyboardShortcutsChanged", handler)
   }, [])
 
   const updateShortcut = (id: string, newKeys: string) => {


### PR DESCRIPTION
## Summary
- ignore modifier only presses when editing keyboard shortcuts
- broadcast saved shortcut changes so other components refresh

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard shortcut editing to ignore modifier-only key presses, making it easier to set custom shortcuts.

- **New Features**
  - Keyboard shortcut updates now synchronize instantly across different parts of the app without needing a page reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->