### PR TITLE
Add python node editor and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ IFC Flow Map provides a graphical interface for viewing, filtering, transforming
   - 📊 **Analysis Node** - Perform analyses like clash detection
   - 👀 **Watch Node** - Monitor element values
   - ⚙️ **Parameter Node** - Define workflow parameters
+  - 🐍 **Python Node** - Run custom Python scripts
 - 💾 **Workflow Storage** - Save and load workflows
 - ⚡ **Real-time Execution** - Execute workflows and see results immediately
 - ⌨️ **Keyboard Shortcuts** - Efficient workflow creation with keyboard shortcuts

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -462,7 +462,7 @@ function FlowWithProvider() {
   // Handle node double-click to open properties panel
   const onNodeDoubleClick = useCallback(
     (event: React.MouseEvent, node: Node) => {
-      // Only open edit mode on double click if we're not already editing
+      if (node.type === "pythonNode") return;
       if (!editingNode) {
         setEditingNode(node);
       }

--- a/components/dialogs/help-dialog.tsx
+++ b/components/dialogs/help-dialog.tsx
@@ -178,6 +178,17 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
       ],
     },
     {
+      id: "python",
+      title: "Using the Python Node",
+      icon: <Code className="h-5 w-5" />,
+      description: "Run custom scripts to process data.",
+      steps: [
+        'Drag a <i>Python Script</i> node onto the canvas',
+        'Double-click the node to open the editor',
+        'Write code using <code>input_data</code> and press <kbd>Run</kbd>',
+      ],
+    },
+    {
       id: "saving",
       title: "Saving and Loading Workflows",
       icon: <FileJson className="h-5 w-5" />,
@@ -601,6 +612,26 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                     <p>
                       This example shows how to classify and group elements
                       based on their properties and relationships.
+                    </p>
+                  </CardContent>
+                  <CardFooter className="pt-0">
+                    <Button variant="outline" size="sm" className="w-full">
+                      Load Example
+                    </Button>
+                  </CardFooter>
+                </Card>
+
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Python Aggregator</CardTitle>
+                    <CardDescription>
+                      Summarize elements using a Python script
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="text-sm text-muted-foreground">
+                    <p>
+                      This example groups elements by type, computes averages,
+                      and outputs a convenient table.
                     </p>
                   </CardContent>
                   <CardFooter className="pt-0">

--- a/components/nodes/python-script-node.tsx
+++ b/components/nodes/python-script-node.tsx
@@ -3,10 +3,12 @@
 import { memo, useState } from "react"
 import { Handle, Position, NodeProps, useReactFlow } from "reactflow"
 import { Code } from "lucide-react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
 import { PythonScriptNodeData } from "./node-types"
 
 export const PythonScriptNode = memo(({ data, id, isConnectable }: NodeProps<PythonScriptNodeData>) => {
-  const [expanded, setExpanded] = useState(false)
+  const [editorOpen, setEditorOpen] = useState(false)
   const { setNodes } = useReactFlow()
   const script = data.properties?.script || ""
   const consoleText = data.console || ""
@@ -22,33 +24,53 @@ export const PythonScriptNode = memo(({ data, id, isConnectable }: NodeProps<Pyt
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-60 shadow-md">
+    <>
       <div
-        className="bg-orange-500 text-white px-3 py-1 flex items-center justify-between cursor-pointer"
-        onClick={() => setExpanded(!expanded)}
+        className="bg-white dark:bg-gray-800 border-2 border-orange-500 dark:border-orange-400 rounded-md w-48 shadow-md cursor-pointer"
+        onDoubleClick={(e) => {
+          e.stopPropagation()
+          setEditorOpen(true)
+        }}
       >
-        <div className="flex items-center gap-2">
+        <div className="bg-orange-500 text-white px-3 py-1 flex items-center gap-2">
           <Code className="h-4 w-4" />
           <div className="text-sm font-medium truncate" title={data.label}>{data.label}</div>
         </div>
-        <div className="text-xs">{expanded ? "Hide" : "Edit"}</div>
-      </div>
-      {expanded && (
-        <div className="p-2 text-xs space-y-2">
-          <textarea
-            className="w-full h-32 p-1 font-mono border rounded bg-gray-50 dark:bg-gray-900"
-            value={script}
-            onChange={e => updateScript(e.target.value)}
-            placeholder="# Write Python script here"
-          />
-          <div className="h-24 overflow-auto bg-black text-green-300 font-mono p-1 rounded whitespace-pre-wrap">
-            {consoleText || "Console output"}
-          </div>
+        <div className="p-2 text-xs min-h-[40px]">
+          {script ? (
+            <pre className="whitespace-pre-wrap max-h-10 overflow-hidden">{script}</pre>
+          ) : (
+            <span className="text-muted-foreground">Double-click to edit</span>
+          )}
         </div>
-      )}
-      <Handle type="target" position={Position.Left} id="input" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
-      <Handle type="source" position={Position.Right} id="output" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
-    </div>
+        <Handle type="target" position={Position.Left} id="input" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
+        <Handle type="source" position={Position.Right} id="output" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
+      </div>
+
+      <Dialog open={editorOpen} onOpenChange={setEditorOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit Python Script</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 text-sm">
+            <textarea
+              className="w-full h-40 p-2 font-mono border rounded bg-gray-50 dark:bg-gray-900"
+              value={script}
+              onChange={(e) => updateScript(e.target.value)}
+              placeholder="# Write Python script here"
+            />
+            <div className="h-24 overflow-auto bg-black text-green-300 font-mono p-1 rounded whitespace-pre-wrap">
+              {consoleText || "Console output"}
+            </div>
+            <div className="text-right">
+              <Button size="sm" onClick={() => setEditorOpen(false)}>
+                Close
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 })
 


### PR DESCRIPTION
## Summary
- improve documentation with Python node description
- integrate Python node in help dialog
- add Python Aggregator example card
- open a dialog editor for Python nodes on double click
- ignore Python nodes in default node double click handler

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba6cab5c8320847c1afad5e12017