### PR TITLE
Add Python node with IfcOpenShell support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,6 +37,7 @@ import { RelationshipNode } from "@/components/nodes/relationship-node";
 import { AnalysisNode } from "@/components/nodes/analysis-node";
 import { WatchNode } from "@/components/nodes/watch-node";
 import { ParameterNode } from "@/components/nodes/parameter-node";
+import { PythonNode } from "@/components/nodes/python-node";
 import { Toaster } from "@/components/toaster";
 import { WorkflowExecutor } from "@/lib/workflow-executor";
 import { loadIfcFile, getIfcFile, downloadExportedFile } from "@/lib/ifc-utils";
@@ -68,6 +69,7 @@ const nodeTypes: NodeTypes = {
   analysisNode: AnalysisNode,
   watchNode: WatchNode,
   parameterNode: ParameterNode,
+  pythonNode: PythonNode,
 };
 
 // Custom node style to highlight selected nodes

--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -12,6 +12,7 @@ import { RelationshipNode } from "./relationship-node"
 import { AnalysisNode } from "./analysis-node"
 import { WatchNode } from "./watch-node"
 import { ParameterNode } from "./parameter-node"
+import { PythonNode } from "./python-node"
 
 // Define custom node types
 export const nodeTypes = {
@@ -29,6 +30,7 @@ export const nodeTypes = {
   analysisNode: AnalysisNode,
   watchNode: WatchNode,
   parameterNode: ParameterNode,
+  pythonNode: PythonNode,
 }
 
 export {
@@ -46,5 +48,6 @@ export {
   AnalysisNode,
   WatchNode,
   ParameterNode,
+  PythonNode,
 }
 

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -136,4 +136,12 @@ export interface WatchNodeData extends BaseNodeData {
         watchType?: string;
         [key: string]: any;
     };
-} 
+}
+
+// Python node data
+export interface PythonNodeData extends BaseNodeData {
+    properties?: {
+        script?: string;
+        [key: string]: any;
+    };
+}

--- a/components/nodes/python-node.tsx
+++ b/components/nodes/python-node.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { memo, useState, useCallback, useEffect } from "react";
+import { Handle, Position, type NodeProps, useReactFlow } from "reactflow";
+import { Code } from "lucide-react";
+import { PythonNodeData as BasePythonNodeData } from "./node-types";
+import { runPython } from "@/lib/ifc-utils";
+import type { IfcModel } from "@/lib/ifc/ifc-loader";
+
+interface ExtendedPythonNodeData extends BasePythonNodeData {
+  inputData?: IfcModel;
+  result?: any;
+  isRunning?: boolean;
+  error?: string | null;
+}
+
+export const PythonNode = memo(({ id, data, isConnectable }: NodeProps<ExtendedPythonNodeData>) => {
+  const { setNodes } = useReactFlow();
+  const [script, setScript] = useState(data.properties?.script || "");
+
+  useEffect(() => {
+    setScript(data.properties?.script || "");
+  }, [data.properties?.script]);
+
+  const runScript = useCallback(async () => {
+    if (!data.inputData) return;
+    setNodes(nodes => nodes.map(node => node.id === id ? { ...node, data: { ...node.data, isRunning: true, error: null } } : node));
+    try {
+      const result = await runPython(data.inputData, script);
+      setNodes(nodes => nodes.map(node => node.id === id ? { ...node, data: { ...node.data, result, isRunning: false, properties: { ...node.data.properties, script } } } : node));
+    } catch (e: any) {
+      setNodes(nodes => nodes.map(node => node.id === id ? { ...node, data: { ...node.data, isRunning: false, error: e.message } } : node));
+    }
+  }, [data.inputData, id, script, setNodes]);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border-2 border-purple-500 dark:border-purple-400 rounded-md w-64 shadow-md">
+      <div className="bg-purple-500 text-white px-3 py-1 flex items-center gap-2">
+        <Code className="h-4 w-4" />
+        <div className="text-sm font-medium truncate">{data.label}</div>
+      </div>
+      <div className="p-2 text-xs space-y-1">
+        <textarea
+          className="w-full h-24 text-xs font-mono bg-gray-100 dark:bg-gray-900 rounded p-1"
+          value={script}
+          onChange={(e) => setScript(e.target.value)}
+          placeholder="# Python code here\nresult = len(ifc_file.by_type('IfcWall'))"
+        />
+        <button
+          className="text-blue-500 hover:text-blue-700 text-xs"
+          onClick={(e) => { e.stopPropagation(); runScript(); }}
+        >
+          Run
+        </button>
+        {data.isRunning && <div className="text-gray-500">Running...</div>}
+        {data.error && <div className="text-red-500">{data.error}</div>}
+        {data.result !== undefined && !data.isRunning && !data.error && (
+          <div className="break-words">{JSON.stringify(data.result).slice(0, 100)}</div>
+        )}
+      </div>
+      <Handle type="target" position={Position.Left} id="input" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
+      <Handle type="source" position={Position.Right} id="output" style={{ background: "#555", width: 8, height: 8 }} isConnectable={isConnectable} />
+    </div>
+  );
+});
+
+PythonNode.displayName = "PythonNode";

--- a/components/properties-panel/node-property-renderer.tsx
+++ b/components/properties-panel/node-property-renderer.tsx
@@ -794,6 +794,27 @@ export function NodePropertyRenderer({
         </div>
       );
 
+    case "pythonNode":
+      return (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="script">Python Script</Label>
+            <textarea
+              id="script"
+              className="w-full h-32 p-1 font-mono text-xs border rounded"
+              value={properties.script || ""}
+              onChange={(e) =>
+                setProperties({ ...properties, script: e.target.value })
+              }
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Provide Python code that uses <code>ifc_file</code> and
+            <code>ifcopenshell</code>. Assign output to <code>result</code>.
+          </p>
+        </div>
+      );
+
     case "watchNode":
       return (
         <div className="space-y-4">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -35,6 +35,7 @@ import {
   BarChart,
   Download,
   Sliders,
+  Code,
   Search,
   Clock,
   Plus,
@@ -115,6 +116,12 @@ export const nodeCategories = [
         id: "classificationNode",
         label: "Classification",
         icon: <FileText className="h-4 w-4 mr-2" />,
+        status: "new",
+      },
+      {
+        id: "pythonNode",
+        label: "Python",
+        icon: <Code className="h-4 w-4 mr-2" />,
         status: "new",
       },
       {

--- a/lib/ifc-utils.ts
+++ b/lib/ifc-utils.ts
@@ -186,6 +186,11 @@ export async function initializeWorker(): Promise<void> {
           workerPromiseResolvers.get(messageId)!.resolve(data.data);
           workerPromiseResolvers.delete(messageId);
         }
+      } else if (type === "pythonResult") {
+        if (messageId && workerPromiseResolvers.has(messageId)) {
+          workerPromiseResolvers.get(messageId)!.resolve(data.result);
+          workerPromiseResolvers.delete(messageId);
+        }
       }
       // Progress messages don't resolve promises
     };
@@ -1774,4 +1779,39 @@ export function downloadExportedFile(
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+}
+
+// Execute custom Python code using the IFC worker
+export async function runPython(model: IfcModel, code: string): Promise<any> {
+  await initializeWorker();
+  if (!ifcWorker) throw new Error("IFC worker is not available");
+
+  const file = getIfcFile(model.name);
+  if (!file) {
+    throw new Error(`Could not retrieve cached file object for ${model.name}`);
+  }
+  const arrayBuffer = await file.arrayBuffer();
+
+  const messageId = `python_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+
+  const result = await new Promise<any>((resolve, reject) => {
+    workerPromiseResolvers.set(messageId, { resolve, reject });
+    ifcWorker!.postMessage(
+      {
+        action: "runPython",
+        messageId,
+        data: { code, arrayBuffer },
+      },
+      [arrayBuffer]
+    );
+
+    setTimeout(() => {
+      if (workerPromiseResolvers.has(messageId)) {
+        reject(new Error("Worker timeout during Python execution"));
+        workerPromiseResolvers.delete(messageId);
+      }
+    }, 60000);
+  });
+
+  return result;
 }

--- a/lib/workflow-executor.ts
+++ b/lib/workflow-executor.ts
@@ -14,6 +14,7 @@ import {
   IfcModel,
   getLastLoadedModel,
   extractGeometryWithGeom,
+  runPython,
 } from "@/lib/ifc-utils";
 
 // Add TypeScript interfaces at the top of the file
@@ -742,6 +743,18 @@ export class WorkflowExecutor {
               ),
               metric: node.data.properties?.metric || "area",
             }
+          );
+        }
+        break;
+
+      case "pythonNode":
+        if (!inputValues.input) {
+          console.warn(`No input provided to python node ${nodeId}`);
+          result = null;
+        } else {
+          result = await runPython(
+            inputValues.input,
+            node.data.properties?.script || ""
           );
         }
         break;

--- a/public/ifcWorker.js
+++ b/public/ifcWorker.js
@@ -124,6 +124,11 @@ self.onmessage = async (event) => {
         await handleExtractQuantities(data, messageId);
         break;
 
+      case "runPython":
+        console.log("Running custom Python code...");
+        await handleRunPython(data, messageId);
+        break;
+
       default:
         throw new Error(`Unknown action: ${action}`);
     }
@@ -1860,6 +1865,59 @@ except Exception as e:
     self.postMessage({
       type: "error",
       message: `Error extracting quantities: ${error.message}`,
+      messageId,
+    });
+  }
+}
+
+// Execute custom Python code using the loaded IFC model
+async function handleRunPython(data, messageId) {
+  try {
+    await initPyodide();
+    const { code, arrayBuffer } = data;
+
+    if (arrayBuffer) {
+      try {
+        pyodide.FS.writeFile("model.ifc", new Uint8Array(arrayBuffer));
+      } catch (e) {
+        console.error("Failed to write IFC buffer for Python execution", e);
+      }
+    }
+
+    const namespace = pyodide.globals.get("dict")();
+    namespace.set("user_code", code);
+
+    await pyodide.runPythonAsync(
+      `import ifcopenshell, json, traceback
+try:
+    ifc_file = ifcopenshell.open('model.ifc')
+    local_vars = {}
+    exec(user_code, {'ifc_file': ifc_file, 'ifcopenshell': ifcopenshell}, local_vars)
+    result_json = json.dumps(local_vars.get('result'))
+    success = True
+    error_msg = ''
+except Exception as e:
+    success = False
+    error_msg = str(e)
+    result_json = None
+`,
+      { globals: namespace }
+    );
+
+    const success = namespace.get("success");
+    if (!success) {
+      const msg = namespace.get("error_msg");
+      throw new Error(msg);
+    }
+    const resultJson = namespace.get("result_json");
+    const result = resultJson ? JSON.parse(resultJson) : null;
+    namespace.destroy();
+
+    self.postMessage({ type: "pythonResult", messageId, result });
+  } catch (error) {
+    self.postMessage({
+      type: "error",
+      message: `Python execution failed: ${error.message}`,
       messageId,
     });
   }


### PR DESCRIPTION
## Summary
- create Python node component that executes user scripts
- integrate runPython function with IFC worker
- support `runPython` action in public worker
- update workflow executor, sidebar and node mappings

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687b8271442c83209e241a2e5ab29009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Python" node that allows users to write and execute custom Python scripts directly within the workflow, leveraging the IFC model as input.
  * Added a dedicated script editor and run button within the Python node UI for interactive code execution.
  * Included a new entry for the Python node in the sidebar under the "Data" category.

* **Enhancements**
  * The properties panel now supports editing Python scripts for Python nodes, with helpful instructions.
  * Workflow execution engine now processes Python nodes and returns results or error messages as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->