### PR TITLE
feat: add AI chat node

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from "next/server";
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { countElements, sumWallArea, getCachedModel } from "@/lib/ifc/ai-helpers";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const { messages, modelId } = await req.json();
+  const prompt = messages?.[messages.length - 1]?.content || "";
+
+  if (modelId) {
+    const model = getCachedModel(modelId);
+    if (model) {
+      const lower = prompt.toLowerCase();
+      if (lower.includes("how many walls")) {
+        const count = countElements(model, "IfcWall");
+        return new Response(`There are ${count} walls in the model.`);
+      }
+      if (lower.includes("wall") && lower.includes("m") && lower.includes("area")) {
+        const area = sumWallArea(model);
+        return new Response(`Total wall area is ${area} m².`);
+      }
+    }
+  }
+
+  const response = await streamText({
+    model: openai("gpt-3.5-turbo"),
+    messages,
+  });
+  return response.toDataStreamResponse();
+}

--- a/components/nodes/ai-node.tsx
+++ b/components/nodes/ai-node.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "reactflow";
+import { useChat } from "ai/react";
+import { Bot } from "lucide-react";
+import type { AiNodeData } from "./node-types";
+
+export const AiNode = memo(({ data, isConnectable }: NodeProps<AiNodeData>) => {
+  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
+    api: "/api/ai",
+    body: { modelId: data.model?.id }
+  });
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border-2 border-purple-500 rounded-md w-64 shadow-md">
+      <div className="bg-purple-500 text-white px-3 py-1 flex items-center gap-2 rounded-t-md">
+        <Bot className="h-4 w-4" />
+        <div className="text-sm font-medium truncate">{data.label}</div>
+      </div>
+      <div className="p-2 h-40 overflow-y-auto text-xs space-y-1">
+        {messages.map(m => (
+          <div key={m.id} className={m.role === "user" ? "text-right" : "text-left"}>
+            <span className={`${
+              m.role === "user"
+                ? "bg-purple-100 dark:bg-purple-900 text-purple-900 dark:text-purple-100"
+                : "bg-gray-100 dark:bg-gray-700"
+            } inline-block px-2 py-1 rounded`}>
+              {m.content}
+            </span>
+          </div>
+        ))}
+        {isLoading && <div className="text-gray-500">...</div>}
+      </div>
+      <form onSubmit={handleSubmit} className="border-t border-gray-200 dark:border-gray-700 p-2">
+        <input
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Ask..."
+          className="w-full bg-transparent text-xs outline-none"
+        />
+      </form>
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="model"
+        style={{ background: "#555", width: 8, height: 8 }}
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="output"
+        style={{ background: "#555", width: 8, height: 8 }}
+        isConnectable={isConnectable}
+      />
+    </div>
+  );
+});
+
+AiNode.displayName = "AiNode";
+

--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -16,6 +16,7 @@ import { ParameterNode } from "./parameter-node"
 import { PythonNode } from "./python-node"
 import { DataTransformNode } from "./data-transform-node"
 import { ClusterNode } from "./cluster-node"
+import { AiNode } from "./ai-node"
 
 // Define custom node types as a constant to prevent React Flow warning
 export const nodeTypes: NodeTypes = {
@@ -36,6 +37,7 @@ export const nodeTypes: NodeTypes = {
   pythonNode: PythonNode,
   dataTransformNode: DataTransformNode,
   clusterNode: ClusterNode,
+  aiNode: AiNode,
 } as const
 
 export {
@@ -56,5 +58,6 @@ export {
   ParameterNode,
   PythonNode,
   ClusterNode,
+  AiNode,
 }
 

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -1,3 +1,5 @@
+import type { IfcModel } from "@/lib/ifc/ifc-loader";
+
 // Common base interface for all node data
 export interface BaseNodeData {
     label: string;
@@ -88,6 +90,13 @@ export interface PythonNodeData extends BaseNodeData {
         percentage: number;
         message?: string;
     } | null;
+}
+
+// AI node data
+export interface AiNodeData extends BaseNodeData {
+    messages?: Array<{ id: string; role: "user" | "assistant"; content: string }>;
+    isLoading?: boolean;
+    model?: IfcModel | null;
 }
 
 // Property node data

--- a/lib/ifc/ai-helpers.ts
+++ b/lib/ifc/ai-helpers.ts
@@ -1,0 +1,28 @@
+import type { IfcModel } from "./ifc-loader";
+
+const modelCache = new Map<string, IfcModel>();
+
+export function cacheModel(id: string, model: IfcModel) {
+  modelCache.set(id, model);
+}
+
+export function getCachedModel(id: string): IfcModel | undefined {
+  return modelCache.get(id);
+}
+
+export function countElements(model: IfcModel, type: string): number {
+  return model.elements.filter(el => el.type === type).length;
+}
+
+export function sumWallArea(model: IfcModel): number {
+  return model.elements
+    .filter(el => el.type === "IfcWall")
+    .reduce((sum, el) => {
+      const area =
+        el.qtos?.BaseQuantities?.NetSideArea ||
+        el.psets?.BaseQuantities?.NetSideArea ||
+        el.properties?.Area ||
+        0;
+      return sum + Number(area);
+    }, 0);
+}

--- a/lib/workflow-executor.ts
+++ b/lib/workflow-executor.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/ifc-utils";
 import { performAnalysis } from "@/lib/ifc/analysis-utils";
 import { withActiveViewer, hasActiveModel } from "@/lib/ifc/viewer-manager";
+import { cacheModel } from "@/lib/ifc/ai-helpers";
 import * as THREE from "three";
 import { buildClusters, buildClustersFromElements, applyClusterColors, ClusterConfig, getClusterStats } from "@/lib/ifc/cluster-utils";
 
@@ -929,6 +930,24 @@ export class WorkflowExecutor {
           }
         }
         break;
+
+      case "aiNode": {
+        console.log("Processing aiNode", { node, inputValues });
+        const model =
+          inputValues.input && inputValues.input.elements
+            ? (inputValues.input as IfcModel)
+            : null;
+        // Store model reference for chat node
+        if (model) {
+          cacheModel(model.id, model);
+        }
+        this.updateNodeDataInList(nodeId, {
+          ...node.data,
+          model,
+        });
+        result = inputValues.input || null;
+        break;
+      }
 
       case "pythonNode": {
         console.log("Processing pythonNode", { node, inputValues });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ifc-flow",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ifc-flow",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
     "vaul": "^0.9.6",
     "web-ifc": "^0.0.68",
     "xlsx": "^0.18.5",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "ai": "^3.1.0",
+    "@vercel/kv": "^0.2.1",
+    "ifcopenshell": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- add AiNodeData interface and AI node component powered by Vercel AI SDK
- register aiNode type and extend workflow executor to pass IFC models to the chat node
- add server-side AI route and IFC helpers for model queries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(blocked: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a7743ab2548320964686a03122d9b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an AI chat node with a built-in chat UI and connectors for model input and output.
  - Added an AI API endpoint running at the edge that supports streaming responses and can directly answer IFC-related queries (e.g., wall counts and total wall area).
  - Enabled workflows to pass and reuse IFC models within AI interactions.

- Chores
  - Added new dependencies to support AI, data storage, and IFC processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->