### PR TITLE
feat: expand filter node capabilities

### DIFF
--- a/components/nodes/filter-node.tsx
+++ b/components/nodes/filter-node.tsx
@@ -13,21 +13,39 @@ export const FilterNode = memo(({ data, isConnectable }: NodeProps<FilterNodeDat
         <div className="text-sm font-medium truncate">{data.label}</div>
       </div>
       <div className="p-3 text-xs">
-        {data.properties?.property ? (
-          <div className="space-y-1">
-            <div className="flex justify-between">
-              <span>Property:</span>
-              <span className="font-medium">{data.properties.property}</span>
+        {data.properties ? (
+          data.properties.filterType === "storey" ? (
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span>Storey:</span>
+                <span className="font-medium">{data.properties.storey || "Any"}</span>
+              </div>
             </div>
-            <div className="flex justify-between">
-              <span>Operator:</span>
-              <span className="font-medium">{data.properties?.operator || "equals"}</span>
+          ) : data.properties.filterType === "material" ? (
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span>Material:</span>
+                <span className="font-medium">{data.properties.material || "Any"}</span>
+              </div>
             </div>
-            <div className="flex justify-between">
-              <span>Value:</span>
-              <span className="font-medium">{data.properties?.value || ""}</span>
+          ) : data.properties.pset || data.properties.property || data.properties.value ? (
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span>Pset:</span>
+                <span className="font-medium">{data.properties.pset || "Any"}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Property:</span>
+                <span className="font-medium">{data.properties.property || "Any"}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Value:</span>
+                <span className="font-medium">{data.properties.value || ""}</span>
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="text-muted-foreground">No filter configured</div>
+          )
         ) : (
           <div className="text-muted-foreground">No filter configured</div>
         )}

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -40,9 +40,11 @@ export interface ExportNodeData extends BaseNodeData {
 export interface FilterNodeData extends BaseNodeData {
     properties?: {
         filterType?: string;
+        pset?: string;
         property?: string;
         value?: string;
-        operator?: string;
+        storey?: string;
+        material?: string;
         [key: string]: any;
     };
 }

--- a/components/properties-panel/node-property-renderer.tsx
+++ b/components/properties-panel/node-property-renderer.tsx
@@ -107,54 +107,97 @@ export function NodePropertyRenderer({
       return (
         <div className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="property">Property</Label>
-            <Input
-              id="property"
-              list="model-properties"
-              value={properties.property || ""}
-              onChange={(e) =>
-                setProperties({ ...properties, property: e.target.value })
-              }
-              placeholder="e.g. Pset_WallCommon.FireRating"
-            />
-            {modelProps.length > 0 && (
-              <datalist id="model-properties">
-                {modelProps.map((p) => (
-                  <option key={p} value={p} />
-                ))}
-              </datalist>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="operator">Operator</Label>
+            <Label htmlFor="filterType">Filter Type</Label>
             <Select
-              value={properties.operator || "equals"}
+              value={properties.filterType || "property"}
               onValueChange={(value) =>
-                setProperties({ ...properties, operator: value })
+                setProperties({ ...properties, filterType: value })
               }
             >
-              <SelectTrigger id="operator">
-                <SelectValue placeholder="Select operator" />
+              <SelectTrigger id="filterType">
+                <SelectValue placeholder="Select filter type" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="equals">Equals</SelectItem>
-                <SelectItem value="contains">Contains</SelectItem>
-                <SelectItem value="startsWith">Starts With</SelectItem>
-                <SelectItem value="endsWith">Ends With</SelectItem>
+                <SelectItem value="property">Property</SelectItem>
+                <SelectItem value="storey">Building Storey</SelectItem>
+                <SelectItem value="material">Material</SelectItem>
               </SelectContent>
             </Select>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="value">Value</Label>
-            <Input
-              id="value"
-              value={properties.value || ""}
-              onChange={(e) =>
-                setProperties({ ...properties, value: e.target.value })
-              }
-              placeholder="Value to match"
-            />
-          </div>
+
+          {properties.filterType === "storey" && (
+            <div className="space-y-2">
+              <Label htmlFor="storey">Storey</Label>
+              <Input
+                id="storey"
+                value={properties.storey || ""}
+                onChange={(e) =>
+                  setProperties({ ...properties, storey: e.target.value })
+                }
+                placeholder="Any or regex / enumeration"
+              />
+            </div>
+          )}
+
+          {properties.filterType === "material" && (
+            <div className="space-y-2">
+              <Label htmlFor="material">Material</Label>
+              <Input
+                id="material"
+                value={properties.material || ""}
+                onChange={(e) =>
+                  setProperties({ ...properties, material: e.target.value })
+                }
+                placeholder="Any or regex / enumeration"
+              />
+            </div>
+          )}
+
+          {(!properties.filterType || properties.filterType === "property") && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="pset">Pset Name</Label>
+                <Input
+                  id="pset"
+                  value={properties.pset || ""}
+                  onChange={(e) =>
+                    setProperties({ ...properties, pset: e.target.value })
+                  }
+                  placeholder="e.g. Pset_WallCommon"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="property">Property Name</Label>
+                <Input
+                  id="property"
+                  list="model-properties"
+                  value={properties.property || ""}
+                  onChange={(e) =>
+                    setProperties({ ...properties, property: e.target.value })
+                  }
+                  placeholder="e.g. FireRating"
+                />
+                {modelProps.length > 0 && (
+                  <datalist id="model-properties">
+                    {modelProps.map((p) => (
+                      <option key={p} value={p} />
+                    ))}
+                  </datalist>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="value">Value</Label>
+                <Input
+                  id="value"
+                  value={properties.value || ""}
+                  onChange={(e) =>
+                    setProperties({ ...properties, value: e.target.value })
+                  }
+                  placeholder="Regex or comma-separated values"
+                />
+              </div>
+            </>
+          )}
         </div>
       );
 

--- a/components/properties-panel/property-editors/filter-editor.tsx
+++ b/components/properties-panel/property-editors/filter-editor.tsx
@@ -8,9 +8,12 @@ import { getModelPropertyNames } from "@/lib/ifc-utils"
 
 interface FilterEditorProps {
   properties: {
+    filterType?: string;
+    pset?: string;
     property?: string;
-    operator?: string;
     value?: string;
+    storey?: string;
+    material?: string;
     [key: string]: any;
   };
   setProperties: (properties: any) => void;
@@ -22,51 +25,91 @@ export function FilterEditor({ properties, setProperties }: FilterEditorProps) {
   useEffect(() => {
     setModelProps(getModelPropertyNames())
   }, [])
+
+  const filterType = properties.filterType || "property"
+
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor="property">Property</Label>
-        <Input
-          id="property"
-          list="model-properties"
-          value={properties.property || ""}
-          onChange={(e) => setProperties({ ...properties, property: e.target.value })}
-          placeholder="e.g. Pset_WallCommon.FireRating"
-        />
-        {modelProps.length > 0 && (
-          <datalist id="model-properties">
-            {modelProps.map((p) => (
-              <option key={p} value={p} />
-            ))}
-          </datalist>
-        )}
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="operator">Operator</Label>
+        <Label htmlFor="filterType">Filter Type</Label>
         <Select
-          value={properties.operator || "equals"}
-          onValueChange={(value) => setProperties({ ...properties, operator: value })}
+          value={filterType}
+          onValueChange={(value) => setProperties({ ...properties, filterType: value })}
         >
-          <SelectTrigger id="operator">
-            <SelectValue placeholder="Select operator" />
+          <SelectTrigger id="filterType">
+            <SelectValue placeholder="Select filter type" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="equals">Equals</SelectItem>
-            <SelectItem value="contains">Contains</SelectItem>
-            <SelectItem value="startsWith">Starts With</SelectItem>
-            <SelectItem value="endsWith">Ends With</SelectItem>
+            <SelectItem value="property">Property</SelectItem>
+            <SelectItem value="storey">Building Storey</SelectItem>
+            <SelectItem value="material">Material</SelectItem>
           </SelectContent>
         </Select>
       </div>
-      <div className="space-y-2">
-        <Label htmlFor="value">Value</Label>
-        <Input
-          id="value"
-          value={properties.value || ""}
-          onChange={(e) => setProperties({ ...properties, value: e.target.value })}
-          placeholder="Value to match"
-        />
-      </div>
+
+      {filterType === "property" && (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="pset">Pset Name</Label>
+            <Input
+              id="pset"
+              value={properties.pset || ""}
+              onChange={(e) => setProperties({ ...properties, pset: e.target.value })}
+              placeholder="e.g. Pset_WallCommon"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="property">Property Name</Label>
+            <Input
+              id="property"
+              list="model-properties"
+              value={properties.property || ""}
+              onChange={(e) => setProperties({ ...properties, property: e.target.value })}
+              placeholder="e.g. FireRating"
+            />
+            {modelProps.length > 0 && (
+              <datalist id="model-properties">
+                {modelProps.map((p) => (
+                  <option key={p} value={p} />
+                ))}
+              </datalist>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="value">Value</Label>
+            <Input
+              id="value"
+              value={properties.value || ""}
+              onChange={(e) => setProperties({ ...properties, value: e.target.value })}
+              placeholder="Regex or comma-separated values"
+            />
+          </div>
+        </>
+      )}
+
+      {filterType === "storey" && (
+        <div className="space-y-2">
+          <Label htmlFor="storey">Storey</Label>
+          <Input
+            id="storey"
+            value={properties.storey || ""}
+            onChange={(e) => setProperties({ ...properties, storey: e.target.value })}
+            placeholder="Any or regex / enumeration"
+          />
+        </div>
+      )}
+
+      {filterType === "material" && (
+        <div className="space-y-2">
+          <Label htmlFor="material">Material</Label>
+          <Input
+            id="material"
+            value={properties.material || ""}
+            onChange={(e) => setProperties({ ...properties, material: e.target.value })}
+            placeholder="Any or regex / enumeration"
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/lib/ifc-utils.ts
+++ b/lib/ifc-utils.ts
@@ -601,72 +601,116 @@ export async function extractGeometryWithGeom(
 // Filter elements by property
 export function filterElements(
   elements: IfcElement[],
-  property: string,
-  operator: string,
-  value: string
+  options: {
+    filterType?: string;
+    pset?: string;
+    property?: string;
+    value?: string;
+    storey?: string;
+    material?: string;
+  }
 ): IfcElement[] {
-  console.log("Filtering elements:", property, operator, value);
+  const { filterType = "property", pset, property, value, storey, material } = options
+  console.log("Filtering elements:", filterType, options)
 
-  // Add a check for undefined or empty elements
   if (!elements || elements.length === 0) {
-    console.warn("No elements to filter");
-    return [];
+    console.warn("No elements to filter")
+    return []
+  }
+
+  const matchValue = (propValue: any, pattern?: string) => {
+    if (pattern === undefined || pattern === "") return true
+    const str = String(propValue)
+
+    if (pattern.startsWith("/") && pattern.endsWith("/")) {
+      try {
+        const regex = new RegExp(pattern.slice(1, -1))
+        return regex.test(str)
+      } catch {
+        return false
+      }
+    }
+
+    if (pattern.includes(",")) {
+      const values = pattern.split(",").map((v) => v.trim())
+      return values.includes(str)
+    }
+
+    return str === pattern
   }
 
   return elements.filter((element) => {
-    // Split property path (e.g., "Pset_WallCommon.FireRating")
-    const propParts = property.split(".");
+    switch (filterType) {
+      case "storey": {
+        const storeyValue =
+          (element.properties && (element.properties.Level || element.properties.Storey)) ||
+          (element.psets && element.psets.Pset_BuildingStorey && element.psets.Pset_BuildingStorey.Name)
 
-    if (propParts.length === 1) {
-      // Direct property lookup
-      let propValue = element.properties[property];
-      if (propValue === undefined) return false;
-
-      // Convert to string for comparison
-      propValue = String(propValue);
-
-      switch (operator) {
-        case "equals":
-          return propValue === value;
-        case "contains":
-          return propValue.includes(value);
-        case "startsWith":
-          return propValue.startsWith(value);
-        case "endsWith":
-          return propValue.endsWith(value);
-        default:
-          return false;
+        if (!storeyValue) return false
+        return matchValue(storeyValue, storey)
       }
-    } else if (propParts.length === 2) {
-      // Property set lookup (e.g., "Pset_WallCommon.FireRating")
-      const [psetName, propName] = propParts;
 
-      // Check in property sets
-      if (element.psets && element.psets[psetName]) {
-        let propValue = element.psets[psetName][propName];
-        if (propValue === undefined) return false;
-
-        // Convert to string for comparison
-        propValue = String(propValue);
-
-        switch (operator) {
-          case "equals":
-            return propValue === value;
-          case "contains":
-            return propValue.includes(value);
-          case "startsWith":
-            return propValue.startsWith(value);
-          case "endsWith":
-            return propValue.endsWith(value);
-          default:
-            return false;
+      case "material": {
+        let materialValue = element.properties && element.properties.Material
+        if (!materialValue && element.psets) {
+          for (const psetName in element.psets) {
+            const pset = element.psets[psetName]
+            if (pset.Material) {
+              materialValue = pset.Material
+              break
+            }
+          }
         }
+        if (!materialValue) return false
+        return matchValue(materialValue, material)
       }
-      return false;
-    }
 
-    return false;
-  });
+      case "property":
+      default: {
+        if (pset && property) {
+          const propValue = element.psets?.[pset]?.[property]
+          if (propValue === undefined) return false
+          return matchValue(propValue, value)
+        }
+        if (pset && !property) {
+          const psetObj = element.psets?.[pset]
+          if (!psetObj) return false
+          if (!value) return true
+          return Object.values(psetObj).some((v) => matchValue(v, value))
+        }
+        if (!pset && property) {
+          if (element.properties && element.properties[property] !== undefined) {
+            return matchValue(element.properties[property], value)
+          }
+          if (element.psets) {
+            for (const psetName in element.psets) {
+              const psetObj = element.psets[psetName]
+              if (psetObj[property] !== undefined) {
+                return matchValue(psetObj[property], value)
+              }
+            }
+          }
+          return false
+        }
+        // Both pset and property omitted
+        if (!value) return false
+        if (
+          element.properties &&
+          Object.values(element.properties).some((v) => matchValue(v, value))
+        )
+          return true
+        if (element.psets) {
+          for (const psetName in element.psets) {
+            const psetObj = element.psets[psetName]
+            if (Object.values(psetObj).some((v) => matchValue(v, value))) {
+              return true
+            }
+          }
+        }
+        return false
+      }
+    }
+  })
 }
 
 // Transform elements (using geometric transformations)

--- a/lib/ifc/filter-utils.ts
+++ b/lib/ifc/filter-utils.ts
@@ -1,37 +1,89 @@
 import type { IfcElement } from "@/lib/ifc/ifc-loader"
 
-// Mock function to filter elements by property
+// Mock function to filter elements by various criteria
 export function filterElements(
   elements: IfcElement[],
-  property: string,
-  operator: string,
-  value: string,
+  options: {
+    filterType?: string
+    pset?: string
+    property?: string
+    value?: string
+    storey?: string
+    material?: string
+  }
 ): IfcElement[] {
-  console.log("Filtering elements:", property, operator, value)
+  const { filterType = "property", pset, property, value, storey, material } = options
+  const matchValue = (propValue: any, pattern?: string) => {
+    if (!pattern) return true
+    const str = String(propValue)
+    if (pattern.startsWith("/") && pattern.endsWith("/")) {
+      try {
+        const regex = new RegExp(pattern.slice(1, -1))
+        return regex.test(str)
+      } catch {
+        return false
+      }
+    }
+    if (pattern.includes(",")) {
+      const vals = pattern.split(",").map((v) => v.trim())
+      return vals.includes(str)
+    }
+    return str === pattern
+  }
 
   return elements.filter((element) => {
-    const propParts = property.split(".")
-    let propValue: any = element.properties
-
-    for (const part of propParts) {
-      if (!propValue || !propValue[part]) return false
-      propValue = propValue[part]
-    }
-
-    // Ensure we're working with string values for comparison
-    const stringValue = String(propValue)
-
-    switch (operator) {
-      case "equals":
-        return stringValue === value
-      case "contains":
-        return stringValue.includes(value)
-      case "startsWith":
-        return stringValue.startsWith(value)
-      case "endsWith":
-        return stringValue.endsWith(value)
-      default:
+    switch (filterType) {
+      case "storey": {
+        const storeyValue = element.properties?.Level || element.properties?.Storey
+        if (!storeyValue) return false
+        return matchValue(storeyValue, storey)
+      }
+      case "material": {
+        const materialValue = element.properties?.Material
+        if (!materialValue) return false
+        return matchValue(materialValue, material)
+      }
+      case "property":
+      default: {
+        if (pset && property) {
+          const propValue = element.psets?.[pset]?.[property]
+          if (propValue === undefined) return false
+          return matchValue(propValue, value)
+        }
+        if (pset && !property) {
+          const p = element.psets?.[pset]
+          if (!p) return false
+          if (!value) return true
+          return Object.values(p).some((v) => matchValue(v, value))
+        }
+        if (!pset && property) {
+          if (element.properties?.[property] !== undefined) {
+            return matchValue(element.properties[property], value)
+          }
+          if (element.psets) {
+            for (const name in element.psets) {
+              const p = element.psets[name]
+              if (p[property] !== undefined && matchValue(p[property], value)) {
+                return true
+              }
+            }
+          }
+          return false
+        }
+        if (!value) return false
+        if (element.properties && Object.values(element.properties).some((v) => matchValue(v, value))) {
+          return true
+        }
+        if (element.psets) {
+          for (const name in element.psets) {
+            const p = element.psets[name]
+            if (Object.values(p).some((v) => matchValue(v, value))) {
+              return true
+            }
+          }
+        }
         return false
+      }
     }
   })
 }

--- a/lib/workflow-executor.ts
+++ b/lib/workflow-executor.ts
@@ -348,9 +348,7 @@ export class WorkflowExecutor {
 
           result = filterElements(
             elementsToFilter || [],
-            node.data.properties?.property || "",
-            node.data.properties?.operator || "equals",
-            node.data.properties?.value || ""
+            node.data.properties || {}
           );
         }
         break;


### PR DESCRIPTION
## Summary
- allow filter node to filter by property, building storey, or material
- support pset & property fields plus regex or enumeration values
- update backend filtering and workflow executor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3324238883208d2e4276aa321bf6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added filter types: Property (with Pset/Property/Value), Storey, and Material.
  - Filters now support regex patterns and comma-separated values.
- Refactor
  - Reworked filter configuration to use a single “Filter Type” selector with contextual inputs.
  - Updated property suggestions for Property filters via a datalist.
  - Filter node display now reflects the selected filter details or shows “No filter configured.”
  - Removed the previous Operator setting and consolidated value handling with clearer defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->