### PR TITLE
feat: add IFC class filters to filter node

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ IFC Flow Map provides a graphical interface for viewing, filtering, transforming
 - 🧩 **Multiple Node Types**:
   - 📁 **IFC Node** - Import IFC files
   - 📐 **Geometry Node** - Extract geometric information
-  - 🔍 **Filter Node** - Filter elements using IFC properties (`Pset.PropertyName`)
+  - 🔍 **Filter Node** - Filter elements using IFC properties (`Pset.PropertyName`), IFC class, building storey or material
   - 🔄 **Transform Node** - Apply transformations to elements
   - 👁️ **Viewer Node** - Visualize 3D models
   - 📏 **Quantity Node** - Extract quantity information

--- a/components/nodes/filter-node.tsx
+++ b/components/nodes/filter-node.tsx
@@ -14,7 +14,14 @@ export const FilterNode = memo(({ data, isConnectable }: NodeProps<FilterNodeDat
       </div>
       <div className="p-3 text-xs">
         {data.properties ? (
-          data.properties.filterType === "storey" ? (
+          data.properties.filterType === "class" ? (
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span>IFC Class:</span>
+                <span className="font-medium">{data.properties.ifcClass || "Any"}</span>
+              </div>
+            </div>
+          ) : data.properties.filterType === "storey" ? (
             <div className="space-y-1">
               <div className="flex justify-between">
                 <span>Storey:</span>

--- a/components/nodes/node-types.ts
+++ b/components/nodes/node-types.ts
@@ -45,6 +45,7 @@ export interface FilterNodeData extends BaseNodeData {
         value?: string;
         storey?: string;
         material?: string;
+        ifcClass?: string;
         [key: string]: any;
     };
 }

--- a/components/properties-panel/node-property-renderer.tsx
+++ b/components/properties-panel/node-property-renderer.tsx
@@ -13,6 +13,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
 import { DataTransformEditor } from "./property-editors/data-transform-editor";
 
 interface NodePropertyRendererProps {
@@ -121,6 +127,7 @@ export function NodePropertyRenderer({
                 <SelectItem value="property">Property</SelectItem>
                 <SelectItem value="storey">Building Storey</SelectItem>
                 <SelectItem value="material">Material</SelectItem>
+                <SelectItem value="class">IFC Class</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -128,28 +135,69 @@ export function NodePropertyRenderer({
           {properties.filterType === "storey" && (
             <div className="space-y-2">
               <Label htmlFor="storey">Storey</Label>
-              <Input
-                id="storey"
-                value={properties.storey || ""}
-                onChange={(e) =>
-                  setProperties({ ...properties, storey: e.target.value })
-                }
-                placeholder="Any or regex / enumeration"
-              />
+              <TooltipProvider delayDuration={100}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Input
+                      id="storey"
+                      value={properties.storey || ""}
+                      onChange={(e) =>
+                        setProperties({ ...properties, storey: e.target.value })
+                      }
+                      placeholder="Any or regex / enumeration"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="start">
+                    <p>Use ; to list multiple storeys or wrap with / / for regex.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           )}
 
           {properties.filterType === "material" && (
             <div className="space-y-2">
               <Label htmlFor="material">Material</Label>
-              <Input
-                id="material"
-                value={properties.material || ""}
-                onChange={(e) =>
-                  setProperties({ ...properties, material: e.target.value })
-                }
-                placeholder="Any or regex / enumeration"
-              />
+              <TooltipProvider delayDuration={100}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Input
+                      id="material"
+                      value={properties.material || ""}
+                      onChange={(e) =>
+                        setProperties({ ...properties, material: e.target.value })
+                      }
+                      placeholder="Any or regex / enumeration"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="start">
+                    <p>Use ; to list materials or wrap with / / for regex.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          )}
+
+          {properties.filterType === "class" && (
+            <div className="space-y-2">
+              <Label htmlFor="ifcClass">IFC Class</Label>
+              <TooltipProvider delayDuration={100}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Input
+                      id="ifcClass"
+                      value={properties.ifcClass || ""}
+                      onChange={(e) =>
+                        setProperties({ ...properties, ifcClass: e.target.value })
+                      }
+                      placeholder="e.g. IfcWall;IfcSlab"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="start">
+                    <p>Enter IFC class name or ; separated list. Use / / for regex.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           )}
 

--- a/components/properties-panel/property-editors/filter-editor.tsx
+++ b/components/properties-panel/property-editors/filter-editor.tsx
@@ -3,6 +3,12 @@
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from "@/components/ui/tooltip"
 import { useEffect, useState } from "react"
 import { getModelPropertyNames } from "@/lib/ifc-utils"
 
@@ -14,6 +20,7 @@ interface FilterEditorProps {
     value?: string;
     storey?: string;
     material?: string;
+    ifcClass?: string;
     [key: string]: any;
   };
   setProperties: (properties: any) => void;
@@ -43,6 +50,7 @@ export function FilterEditor({ properties, setProperties }: FilterEditorProps) {
             <SelectItem value="property">Property</SelectItem>
             <SelectItem value="storey">Building Storey</SelectItem>
             <SelectItem value="material">Material</SelectItem>
+            <SelectItem value="class">IFC Class</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -90,24 +98,63 @@ export function FilterEditor({ properties, setProperties }: FilterEditorProps) {
       {filterType === "storey" && (
         <div className="space-y-2">
           <Label htmlFor="storey">Storey</Label>
-          <Input
-            id="storey"
-            value={properties.storey || ""}
-            onChange={(e) => setProperties({ ...properties, storey: e.target.value })}
-            placeholder="Any or regex / enumeration"
-          />
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Input
+                  id="storey"
+                  value={properties.storey || ""}
+                  onChange={(e) => setProperties({ ...properties, storey: e.target.value })}
+                  placeholder="Any or regex / enumeration"
+                />
+              </TooltipTrigger>
+              <TooltipContent side="top" align="start">
+                <p>Use ; to list multiple storeys or wrap with / / for regex.</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       )}
 
       {filterType === "material" && (
         <div className="space-y-2">
           <Label htmlFor="material">Material</Label>
-          <Input
-            id="material"
-            value={properties.material || ""}
-            onChange={(e) => setProperties({ ...properties, material: e.target.value })}
-            placeholder="Any or regex / enumeration"
-          />
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Input
+                  id="material"
+                  value={properties.material || ""}
+                  onChange={(e) => setProperties({ ...properties, material: e.target.value })}
+                  placeholder="Any or regex / enumeration"
+                />
+              </TooltipTrigger>
+              <TooltipContent side="top" align="start">
+                <p>Use ; to list materials or wrap with / / for regex.</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      )}
+
+      {filterType === "class" && (
+        <div className="space-y-2">
+          <Label htmlFor="ifcClass">IFC Class</Label>
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Input
+                  id="ifcClass"
+                  value={properties.ifcClass || ""}
+                  onChange={(e) => setProperties({ ...properties, ifcClass: e.target.value })}
+                  placeholder="e.g. IfcWall;IfcSlab"
+                />
+              </TooltipTrigger>
+              <TooltipContent side="top" align="start">
+                <p>Enter IFC class name or ; separated list. Use / / for regex.</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       )}
     </div>

--- a/lib/ifc-utils.ts
+++ b/lib/ifc-utils.ts
@@ -608,9 +608,18 @@ export function filterElements(
     value?: string;
     storey?: string;
     material?: string;
+    ifcClass?: string;
   }
 ): IfcElement[] {
-  const { filterType = "property", pset, property, value, storey, material } = options
+  const {
+    filterType = "property",
+    pset,
+    property,
+    value,
+    storey,
+    material,
+    ifcClass,
+  } = options
   console.log("Filtering elements:", filterType, options)
 
   if (!elements || elements.length === 0) {
@@ -621,22 +630,28 @@ export function filterElements(
   const matchValue = (propValue: any, pattern?: string) => {
     if (pattern === undefined || pattern === "") return true
     const str = String(propValue)
+    const strLower = str.toLowerCase()
 
     if (pattern.startsWith("/") && pattern.endsWith("/")) {
       try {
-        const regex = new RegExp(pattern.slice(1, -1))
+        const regex = new RegExp(pattern.slice(1, -1), "i")
         return regex.test(str)
       } catch {
         return false
       }
     }
 
-    if (pattern.includes(",")) {
-      const values = pattern.split(",").map((v) => v.trim())
-      return values.includes(str)
+    if (pattern.includes(";")) {
+      const values = pattern.split(";").map((v) => v.trim().toLowerCase())
+      return values.includes(strLower)
     }
 
-    return str === pattern
+    if (pattern.includes(",")) {
+      const values = pattern.split(",").map((v) => v.trim().toLowerCase())
+      return values.includes(strLower)
+    }
+
+    return strLower === pattern.toLowerCase()
   }
 
   return elements.filter((element) => {
@@ -663,6 +678,12 @@ export function filterElements(
         }
         if (!materialValue) return false
         return matchValue(materialValue, material)
+      }
+
+      case "class": {
+        const classValue = element.type
+        if (!classValue) return false
+        return matchValue(classValue, ifcClass)
       }
 
       case "property":

--- a/lib/ifc/filter-utils.ts
+++ b/lib/ifc/filter-utils.ts
@@ -10,25 +10,39 @@ export function filterElements(
     value?: string
     storey?: string
     material?: string
+    ifcClass?: string
   }
 ): IfcElement[] {
-  const { filterType = "property", pset, property, value, storey, material } = options
+  const {
+    filterType = "property",
+    pset,
+    property,
+    value,
+    storey,
+    material,
+    ifcClass,
+  } = options
   const matchValue = (propValue: any, pattern?: string) => {
     if (!pattern) return true
     const str = String(propValue)
+    const strLower = str.toLowerCase()
     if (pattern.startsWith("/") && pattern.endsWith("/")) {
       try {
-        const regex = new RegExp(pattern.slice(1, -1))
+        const regex = new RegExp(pattern.slice(1, -1), "i")
         return regex.test(str)
       } catch {
         return false
       }
     }
-    if (pattern.includes(",")) {
-      const vals = pattern.split(",").map((v) => v.trim())
-      return vals.includes(str)
+    if (pattern.includes(";")) {
+      const vals = pattern.split(";").map((v) => v.trim().toLowerCase())
+      return vals.includes(strLower)
     }
-    return str === pattern
+    if (pattern.includes(",")) {
+      const vals = pattern.split(",").map((v) => v.trim().toLowerCase())
+      return vals.includes(strLower)
+    }
+    return strLower === pattern.toLowerCase()
   }
 
   return elements.filter((element) => {
@@ -42,6 +56,11 @@ export function filterElements(
         const materialValue = element.properties?.Material
         if (!materialValue) return false
         return matchValue(materialValue, material)
+      }
+      case "class": {
+        const classValue = element.type
+        if (!classValue) return false
+        return matchValue(classValue, ifcClass)
       }
       case "property":
       default: {


### PR DESCRIPTION
## Summary
- allow filtering by IFC class with semicolon lists
- support multi-value filters for storey and material
- document filter options and usage tooltips

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*


------
https://chatgpt.com/codex/tasks/task_e_68ab5704b08c8320b39cae3e7f295d06